### PR TITLE
Rename artifact so it doesn't appear as ``.zip.zip`` in artifact page.

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -98,5 +98,5 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4.3.3
       with:
-        name: pack_snapshot.zip
+        name: pack_snapshot
         path: ./


### PR DESCRIPTION
title, the artifact has a zip suffix itself by default.